### PR TITLE
fix/merge_stops: merge stops with same lat/long

### DIFF
--- a/kmb.go
+++ b/kmb.go
@@ -114,6 +114,7 @@ func kmb_route_list() []route {
 	var routes []route
 
 	resp, err := http.Get("https://data.etabus.gov.hk/v1/transport/kmb/route/")
+
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Some stops have the same lat/long and should be treated as one stop when displayed on a map. 

This PR merges them into one stop and then adjusts the route/stop builder to match those routes to the same stop.